### PR TITLE
Add walking condition to path object handler

### DIFF
--- a/src/main/java/org/powbot/dax/engine/WalkerEngine.java
+++ b/src/main/java/org/powbot/dax/engine/WalkerEngine.java
@@ -88,10 +88,10 @@ public class WalkerEngine implements Loggable {
             resetAttempts();
 
             while (true) {
-
                 if(ScriptManager.INSTANCE.isStopping()){
                     return false;
                 }
+
                 if(ScriptManager.INSTANCE.isPaused()){
                     WaitFor.milliseconds(1000);
                     continue;
@@ -105,10 +105,9 @@ public class WalkerEngine implements Loggable {
                 if (wantedEnergy >= Movement.energyLevel() && !Movement.running()) {
                     Movement.running(true);
                 }
-                
+
                 if(walkingCondition != null){
                     switch (walkingCondition.action()){
-
                         case EXIT_OUT_WALKER_SUCCESS:
                             return true;
                         case EXIT_OUT_WALKER_FAIL:
@@ -145,11 +144,9 @@ public class WalkerEngine implements Loggable {
                 RealTimeCollisionTile currentNode = destinationDetails.getDestination();
                 Tile assumedNext = destinationDetails.getAssumed();
 
-
-
 //                if (destinationDetails.getState() != PathAnalyzer.PathState.FURTHEST_CLICKABLE_TILE) {
-                    log(destinationDetails.toString());
-//                } 
+                log(destinationDetails.toString());
+//                }
 
                 final RealTimeCollisionTile destination = currentNode;
                 if (!Projection.isInMinimap(new Tile(destination.getX(), destination.getY(), destination.getZ()))) {
@@ -167,7 +164,7 @@ public class WalkerEngine implements Loggable {
                             WaitFor.milliseconds(1200, 3400);
                         }
                         NavigationSpecialCase.SpecialLocation specialLocation = NavigationSpecialCase.getLocation(currentNode.getTile()),
-                            specialLocationDestination = NavigationSpecialCase.getLocation(assumedNext);
+                                specialLocationDestination = NavigationSpecialCase.getLocation(assumedNext);
                         if (specialLocation != null && specialLocationDestination != null) {
                             log("[SPECIAL LOCATION] We are at " + specialLocation + " and our destination is " + specialLocationDestination);
                             if (!NavigationSpecialCase.handle(specialLocationDestination)) {
@@ -180,8 +177,8 @@ public class WalkerEngine implements Loggable {
                         }
 
                         Charter.LocationProperty
-                            locationProperty = Charter.LocationProperty.getLocation(currentNode.getTile()),
-                            destinationProperty = Charter.LocationProperty.getLocation(assumedNext);
+                                locationProperty = Charter.LocationProperty.getLocation(currentNode.getTile()),
+                                destinationProperty = Charter.LocationProperty.getLocation(assumedNext);
                         if (locationProperty != null && destinationProperty != null) {
                             log("Chartering to: " + destinationProperty);
                             if (!Charter.to(destinationProperty)) {
@@ -196,10 +193,12 @@ public class WalkerEngine implements Loggable {
                         Tile walkingTile = Reachable.getBestWalkableTile(destination.getTile(), new Reachable());
                         if (isDestinationClose(destination) || (walkingTile != null ? AccurateMouse.clickMinimap(walkingTile) : clickMinimap(destination))) {
                             log("Handling Object...");
-                            if (!PathObjectHandler.handle(destinationDetails, path)) {
+
+                            if (!PathObjectHandler.handle(destinationDetails, path, walkingCondition)) {
                                 log("Failed to handle object.");
                                 failedAttempt();
                             } else {
+                                log("Successfully handled object.");
                                 successfulAttempt();
                                 WaitFor.milliseconds(200,800);
                             }


### PR DESCRIPTION
This pull requests aims to add support for the walking condition to the path object handler, to make sure that the condition is respected during object interaction. Backing discussion can be found on the Discord at https://discord.com/channels/341014842745815054/1146046176215449722.

Main change was done in PathObjectHandler, L420 to L425, which adds an additional condition to the wait condition, to be able to early exit if walk condition returns exit. Furthermore, the walking condition is passed from the WalkerEngine to the PathObjectHandler to be able to support this behaviour.

Note, my IDE made some automatic formatting changes to the target files. I'm happy to revert these formatting changes if necessary.