### PR TITLE
Charter location: Sunset Coast: Fixed typo in tile

### DIFF
--- a/src/main/java/org/powbot/dax/engine/navigation/Charter.java
+++ b/src/main/java/org/powbot/dax/engine/navigation/Charter.java
@@ -87,7 +87,7 @@ public class Charter implements Loggable {
         PORT_TYRAS ("Port Tyras", new Tile(2142, 3122, 0)),
         PRIFDDINAS ("Prifddinas", new Tile(2159, 3329, 0)),
         SHIPYARD ("Shipyard", new Tile(3001, 3032, 0)),
-        SUNSET_COAST("Sunset Coast", new Tile(1514, 2871, 0)),
+        SUNSET_COAST("Sunset Coast", new Tile(1514, 2971, 0)),
 
         ;
 


### PR DESCRIPTION
The tile location of the sunset coast seems to be off:
<img width="206" alt="image" src="https://github.com/user-attachments/assets/bc942c6d-b37b-4a49-9116-be3cdfc1f5dd">

This PR moves the tile up to 2971, which is on the docks.
